### PR TITLE
Feature/03 pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,5 +82,3 @@ gem 'mini_magick'
 gem 'faker'
 #ページネーション機能実装
 gem 'kaminari'
-#ページネーションのbootstrap
-gem 'kaminari-bootstrap'

--- a/Gemfile
+++ b/Gemfile
@@ -65,12 +65,22 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+#拡張子をslimに変更
 gem 'slim-rails'
 gem 'html2slim'
+#スキーマ情報をモデルに自動記載
 gem 'annotate'
+#セッションをredisサーバーに管理
 gem 'redis-rails'
+#ログイン機能管理
 gem 'sorcery'
-gem 'rails-i18n'
+#画像アップロード機能
 gem 'carrierwave'
+#画像リサイズ
 gem 'mini_magick'
+#偽データ作成
 gem 'faker'
+#ページネーション機能実装
+gem 'kaminari'
+#ページネーションのbootstrap
+gem 'kaminari-bootstrap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,21 @@ GEM
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     jwt (2.2.2)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-bootstrap (3.0.1)
+      kaminari (>= 0.13.0)
+      rails
+    kaminari-core (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -173,9 +188,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails-i18n (5.1.3)
-      i18n (>= 0.7, < 2)
-      railties (>= 5.0, < 6)
     railties (5.2.4.4)
       actionpack (= 5.2.4.4)
       activesupport (= 5.2.4.4)
@@ -297,6 +309,8 @@ DEPENDENCIES
   faker
   html2slim
   jbuilder (~> 2.5)
+  kaminari
+  kaminari-bootstrap
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
@@ -304,7 +318,6 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
-  rails-i18n
   redis-rails
   rubocop
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,9 +118,6 @@ GEM
     kaminari-activerecord (1.2.1)
       activerecord
       kaminari-core (= 1.2.1)
-    kaminari-bootstrap (3.0.1)
-      kaminari (>= 0.13.0)
-      rails
     kaminari-core (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -310,7 +307,6 @@ DEPENDENCIES
   html2slim
   jbuilder (~> 2.5)
   kaminari
-  kaminari-bootstrap
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -117,3 +117,7 @@ ul {
 .hidden {
   display: none;
 }
+
+.pagination {
+  justify-content: center;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,6 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
-    @post.images.build
   end
 
   def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,12 +3,13 @@ class PostsController < ApplicationController
   before_action :set_post, only: [:show, :edit, :update, :destroy]
 
   def index
-    @posts = Post.all.includes(:images,:user).order(id: :desc).page(params[:page]).per(15)
+    @posts = Post.all.includes(:images,:user).page(params[:page]).order(id: :desc)
     @users = User.all.order(id: :desc)
   end
 
   def new
     @post = Post.new
+    @post.images.build
   end
 
   def create
@@ -25,11 +26,11 @@ class PostsController < ApplicationController
   end
 
   def update
-    if @post.update(post_params)
+    if @post.update(update_post_params)
       redirect_to root_path, success: "更新しました"
     else
       flash[:danger] = '更新に失敗しました'
-    　render :edit
+      render :edit
     end
   end
 
@@ -46,6 +47,10 @@ class PostsController < ApplicationController
 
   def post_params
     params.require(:post).permit(:content, images_attributes: [:file])
+  end
+
+  def update_post_params
+    params.require(:post).permit(:content, images_attributes: [:file, :_destroy, :id])
   end
 
   def set_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: [:show, :edit, :update, :destroy]
 
   def index
-    @posts = Post.all.includes(:images,:user).order(id: :desc)
+    @posts = Post.all.includes(:images,:user).order(id: :desc).page(params[:page]).per(15)
     @users = User.all.order(id: :desc)
   end
 

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,2 @@
+li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,6 @@
+- if page.current?
+  li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link'
+- else
+  li.page-item
+    = link_to page, url, remote: remote, rel: page.rel, class: 'page-link'

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,12 @@
+= paginator.render do
+  nav
+    ul.pagination
+      == first_page_tag unless current_page.first?
+      == prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          == page_tag page
+        - elsif !page.was_truncated?
+          == gap_tag
+      == next_page_tag unless current_page.last?
+      == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,19 +1,10 @@
 = form_with model: post, class: 'form', id: 'posts_form', local: true do |f|
   = render 'shared/error_messages', object: post
-  .form-image
-    .form-image__title
-      label 画像
-      .form-image__text
-        | 最大10枚まで
-        = f.fields_for :images do |c|
-          ul#previews
-            li.input
-              label.upload-label
-                i class = "fas fa-camera"
-                .upload-label__text
-                  | ファイルをアップロード
-                  .input-area
-                    = c.file_field :url, multiple: true,  class: "hidden image_upload"
+  .form-group
+    = f.label :images, "画像"
+    = f.fields_for :images do |c|
+      = c.file_field :file, multiple: true,  class: "form-control"
+      = c.hidden_field :id, value: c.object.id
   .form-group
     = f.label :content, "本文"
     = f.text_area :content, class: 'form-control'

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -15,8 +15,7 @@
       .swiper-wrapper
         - post.images.each do |img|
           .swiper-slide
-            = image_tag img.swiper.url, class: "card-img-top"
+            = image_tag img.file.swiper.url, class: "card-img-top"
       .swiper-pagination
-    .card-body
-      .card-text
-        = post.content
+  .card-body
+    .card-text = post.content

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -4,13 +4,23 @@ main
       .col-md-6.col-12.offset-md-3
         .card
           .card-body
-            = form_with model: @post, id: 'posts_form', local: true do |f|
+            = form_with model: @post, local: true do |f|
               .form-group
-                = f.label :image, "画像"
-                = f.file_field :image, id: 'post_images', class: 'form-control'
-                = image_tag @post.image.thumbnil.url, class: 'image-thumbnail '
+                = f.label :images, "画像"
+                  = f.fields_for :images do |c|
+                    = c.file_field :file, mutiple: true, class: "form-control"
+                .swiper-container.top-carousel
+                  .swiper-wrapper
+                    - @post.images.each do |img|
+                      .swiper-slide
+                        = image_tag img.file.thumbnil.url, class: "image-thumbnail"
+                  .swiper-pagination
               .form-group
                 = f.label :content, "本文"
                 = f.text_area :content, class: 'form-control'
-              = f.submit '更新する', class: 'btn btn-raised btn-primary'
+              = f.submit "更新する", class: 'btn btn-primary btn-raised'
+
 #modal-container
+
+
+= javascript_include_tag "application"

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -23,9 +23,9 @@
                          = link_to post do
                           = image_tag img.file.swiper.url, class: "card-img-top"
                   .swiper-pagination
-        = paginate @posts
               .card-body
                 .card-text = post.content
+        = paginate @posts
       .col-md-4.col-12
         .users-box
           .card

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,30 +1,7 @@
 .container
     .row
       .col-md-8.col-12
-        - @posts.each do |post|
-            .card.mb-5.post
-              .card-header
-                .d-flex.align-items-center
-
-                  = link_to user_path(post.user) do
-                    = image_tag  "default.png", class: "rounded-circle mr-1"
-                    = post.user.name
-                  - if current_user && current_user.id == post.user_id
-                    .ml-auto
-                      = link_to post_path(post), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "mr-3 delete-button" do
-                        i class = "far fa-trash-alt fa-lg"
-                      = link_to edit_post_path(post), class: "edit-button" do
-                        i class = "far fa-edit fa-lg"
-              .swiper-container.top-carousel
-                  .swiper-wrapper(style="transform: translate3d(0px, 0px, 0px)")
-
-                    - post.images.each do |img|
-                      .swiper-slide(style="width: 400px;")
-                         = link_to post do
-                          = image_tag img.file.swiper.url, class: "card-img-top"
-                  .swiper-pagination
-              .card-body
-                .card-text = post.content
+        = render @posts
         = paginate @posts
       .col-md-4.col-12
         .users-box

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -15,7 +15,6 @@
                         i class = "far fa-trash-alt fa-lg"
                       = link_to edit_post_path(post), class: "edit-button" do
                         i class = "far fa-edit fa-lg"
-
               .swiper-container.top-carousel
                   .swiper-wrapper(style="transform: translate3d(0px, 0px, 0px)")
 
@@ -24,7 +23,7 @@
                          = link_to post do
                           = image_tag img.file.swiper.url, class: "card-img-top"
                   .swiper-pagination
-
+        = paginate @posts
               .card-body
                 .card-text = post.content
       .col-md-4.col-12

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -2,7 +2,7 @@
 
 Kaminari.configure do |config|
   # config.default_per_page = 25
-  # config.max_per_page = nil
+  config.default_per_page = 15
   # config.window = 5
   # config.outer_window = 0
   # config.left = 0

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 5
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,7 @@
                )
 end
 
-50.times do |n|
+100.times do |n|
   content = Faker::Quote.famous_last_words
 
   post = Post.new(content: content,
@@ -25,7 +25,7 @@ end
                  )
 
   rand(1..10).times do
-     post.images_attributes = [url: File.open("./public/images/IMG_4060.jpeg")]
+     post.images_attributes = [file: File.open("./public/images/IMG_4060.jpeg")]
 
   end
 


### PR DESCRIPTION
# 03 ページネーションの実装
## 内容
- kaminariを導入しページネーションの設定を行いました。
- ページネーションのデザイン設定にはbootstrap4を適用
- 1ページあたり投稿数15件を表示できるように設定、それ以外はデフォルトのままの設定
- postのindexとnewのパーシャル化を行いました
- 投稿編集の際にエラーが起こることに気づいたので、accepts_nested_attributes_forに対応した実装をしてみました。
具体的には、このQiitaの記事を参考にさせていただいています。→[Qiita](https://qiita.com/kouuuki/items/5daf2b5f34273d8457f7)

## コメント
accepts_nested_attributes_forなどの点に関して、ダイソンさんの答えと違う方法であるのでレビューの仕事量を増やしてしまって申し訳ないです。

