### PR TITLE
Feature/16 system spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,9 +64,7 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
-  gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,6 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.1)
     bcrypt (3.1.16)
@@ -78,10 +76,8 @@ GEM
       image_processing (~> 1.1)
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
-    childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     config (2.2.3)
@@ -152,7 +148,6 @@ GEM
     image_processing (1.11.0)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    io-like (0.3.1)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     jwt (2.2.2)
@@ -318,7 +313,7 @@ GEM
       ffi (~> 1.9)
     ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
-    rubyzip (2.3.0)
+    rubyzip (1.2.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -330,9 +325,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (3.6.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     sidekiq (6.1.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -380,6 +375,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -397,7 +396,6 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   carrierwave
-  chromedriver-helper
   config
   factory_bot_rails
   faker
@@ -419,7 +417,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (~> 5.0)
-  selenium-webdriver
   sidekiq
   sinatra
   slim-rails
@@ -430,6 +427,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
 
 RUBY VERSION
    ruby 2.6.4p104

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
   before_action :set_search_posts_form
+  add_flash_types :success, :info, :warning, :danger
 
   protected
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
-  skip_before_action :require_login, only: [:index, :show]
-  before_action :set_post, only: [:show, :edit, :update, :destroy]
+  skip_before_action :require_login, only: %i[:index, :show]
+  before_action :set_post, only: %i[:edit, :update, :destroy]
 
   def index
     @posts = if current_user
@@ -42,6 +42,7 @@ class PostsController < ApplicationController
   end
 
   def show
+    @post = Post.find(params[:id])
     @comment = Comment.new
     # 新着順で表示、N+1問題に対応するためincludesを用いている
     @comments = @post.comments.includes(:user).order(created_at: :desc)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
-  skip_before_action :require_login, only: %i[:index, :show]
-  before_action :set_post, only: %i[:edit, :update, :destroy]
+  skip_before_action :require_login, only: [:index, :show]
+  before_action :set_post, only: [:edit, :update, :destroy]
 
   def index
     @posts = if current_user

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,9 +29,9 @@ class PostsController < ApplicationController
 
   def update
     if @post.update(post_params)
-      redirect_to root_path, success: '更新しました'
+      redirect_to root_path, success: '投稿を更新しました'
     else
-      flash[:danger] = '更新に失敗しました'
+      flash[:danger] = '投稿の更新に失敗しました'
       render :edit
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -38,7 +38,7 @@ class PostsController < ApplicationController
 
   def destroy
     @post.destroy
-    redirect_to root_path
+    redirect_to root_path, success: '投稿を削除しました'
   end
 
   def show
@@ -58,6 +58,6 @@ class PostsController < ApplicationController
   end
 
   def set_post
-    @post = Post.find(params[:id])
+    @post = current_user.posts.find(params[:id])
   end
 end

--- a/app/views/posts/_like.html.slim
+++ b/app/views/posts/_like.html.slim
@@ -1,6 +1,6 @@
 - if current_user.like?(post)
-  = link_to like_path(current_user.likes.find_by(post_id: post.id)), remote: true, method: :delete, id: "unlike-button" do
+  = link_to like_path(current_user.likes.find_by(post_id: post.id)), remote: true, method: :delete, class: "unlike-button" do
     .fa.fa-heart.fa-lg
 - else
-  = link_to likes_path(post_id: post.id), remote: true, method: :post, id: "like-button" do
+  = link_to likes_path(post_id: post.id), remote: true, method: :post, class: "like-button" do
     .far.fa-heart.fa-lg

--- a/app/views/posts/_like.html.slim
+++ b/app/views/posts/_like.html.slim
@@ -1,6 +1,6 @@
 - if current_user.like?(post)
-  = link_to like_path(current_user.likes.find_by(post_id: post.id)), remote: true, method: :delete, class: "unlike-button" do
+  = link_to like_path(current_user.likes.find_by(post_id: post.id)), remote: true, method: :delete, id: "unlike-button" do
     .fa.fa-heart.fa-lg
 - else
-  = link_to likes_path(post_id: post.id), remote: true, method: :post, class: "like-button" do
+  = link_to likes_path(post_id: post.id), remote: true, method: :post, id: "like-button" do
     .far.fa-heart.fa-lg

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -8,15 +8,15 @@
           /ぼっち演算子を用いてnilを返すようにする/
         - if current_user&.own?(post)
             .ml-auto
-              = link_to post_path(post), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "mr-3", id: 'delete' do
+              = link_to post_path(post), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "mr-3 delete-button" do
                 i class = "far fa-trash-alt fa-lg"
-              = link_to edit_post_path(post), id: 'edit' do
+              = link_to edit_post_path(post), class: 'edit-button' do
                 i class = "far fa-edit fa-lg"
         - if current_user && !current_user&.own?(post)
             .ml-auto
               div id = "like_area-#{post.id}"
                 = render "like", post: post
-  = link_to post_path(post), id: 'show' do
+  = link_to post_path(post) do
     .swiper-container.top-carousel
       .swiper-wrapper
         - post.images.each do |img|

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -1,21 +1,22 @@
 .card.mb-5.post
-  .card-header
-    .d-flex.align-items-center
+  div id = "post-#{post.id}"
+    .card-header
+      .d-flex.align-items-center
         = image_tag  post.user.avatar.url, class: "rounded-circle mr-1", width: "40", height: "40"
         = link_to user_path(post.user) do
           = post.user.name
-        /ぼっち演算子を用いてnilの時にはnilを返すようにする/
+          /ぼっち演算子を用いてnilを返すようにする/
         - if current_user&.own?(post)
-          .ml-auto
-              = link_to post_path(post), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "mr-3" do
+            .ml-auto
+              = link_to post_path(post), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "mr-3", id: 'delete' do
                 i class = "far fa-trash-alt fa-lg"
-              = link_to edit_post_path(post) do
+              = link_to edit_post_path(post), id: 'edit' do
                 i class = "far fa-edit fa-lg"
         - if current_user && !current_user&.own?(post)
-          .ml-auto
-            div id = "like_area-#{post.id}"
-              = render "like", post: post
-  = link_to post_path(post) do
+            .ml-auto
+              div id = "like_area-#{post.id}"
+                = render "like", post: post
+  = link_to post_path(post), id: 'show' do
     .swiper-container.top-carousel
       .swiper-wrapper
         - post.images.each do |img|

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -9,7 +9,7 @@ main
           .form-group
               = f.label :password, 'パスワード　', class: 'bmd-label-floating'
               = f.password_field :password, class: 'form-control'
-          = f.submit 'ログイン', class: 'btn btn-raised btn-primary'
+          = f.submit 'ログイン', class: 'btn btn-raised btn-primary', id: 'login'
       .card
           .card-body
             | アカウントをお持ちでないですか？

--- a/app/views/users/_follow.html.slim
+++ b/app/views/users/_follow.html.slim
@@ -1,4 +1,4 @@
 //modelオプションを調べる！挙動がよくわかっていないので
 = form_with(model: current_user.follow_relationships.build) do |f|
   = f.hidden_field :followed_id, value: user.id
-  = f.submit "フォロー", class: "btn btn-raised btn-outline-warning"
+  = f.submit "フォロー", class: "btn btn-raised btn-outline-warning", id: "follow"

--- a/app/views/users/_unfollow.html.slim
+++ b/app/views/users/_unfollow.html.slim
@@ -1,3 +1,3 @@
-= form_with(model: current_user.follow_relationships.find_by(followed_id: user.id),method: :delete) do |f|
+= form_with(model: current_user.follow_relationships.find_by(followed_id: user.id), method: :delete) do |f|
   = f.hidden_field :followed_id, value: user.id
-  = f.submit "アンフォロー", class: "btn btn-warning btn-raised"
+  = f.submit "アンフォロー", class: "btn btn-warning btn-raised", id: "unfollow"

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -4,16 +4,16 @@
       = form_with model: @user, class: 'card-body', local: true do |f|
         = render 'shared/error_messages', object: @user
         .form-group
-          = f.label :name, 'ユーザー名', class: 'bmd-label-floating'
+          = f.label :name, class: 'bmd-label-floating'
           = f.text_field :name, class: 'form-control'
         .form-group
-          = f.label :email, ' メールアドレス', class: 'bmd-label-floating'
+          = f.label :email, class: 'bmd-label-floating'
           = f.text_field :email, class: 'form-control'
         .form-group
-          = f.label :password, 'パスワード　', class: 'bmd-label-floating'
+          = f.label :password, class: 'bmd-label-floating'
           = f.password_field :password, class: 'form-control'
         .form-group
-          = f.label :password_confirmation, "パスワード(確認)", class: 'bmd-label-floating'
+          = f.label :password_confirmation, class: 'bmd-label-floating'
           = f.password_field :password_confirmation, class: 'form-control'
         = f.submit '登録', class: 'btn btn-raised btn-primary'
     .card

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,25 +1,22 @@
-
-main
-  .login-register-form
-    .login-register-form-inner
-      .card.mb-3
-        = form_with model: @user, class: 'card-body', local: true do |f|
-          = render 'shared/error_messages', object: @user
-          .form-group
-            = f.label :name, 'ユーザー名', class: 'bmd-label-floating'
-            = f.text_field :name, class: 'form-control'
-          .form-group
-            = f.label :email, ' メールアドレス', class: 'bmd-label-floating'
-            = f.text_field :email, class: 'form-control'
-          .form-group
-            = f.label :password, 'パスワード　', class: 'bmd-label-floating'
-            = f.password_field :password, class: 'form-control'
-          .form-group
-            = f.label :password_confirmation, "パスワード(確認)", class: 'bmd-label-floating'
-            = f.password_field :password_confirmation, class: 'form-control'
-          = f.submit '登録', class: 'btn btn-raised btn-primary'
-      .card
-        .card-body
-          | アカウントをお持ちですか
-          = link_to  "ログインする", login_path
-  #modal-container
+.login-register-form
+  .login-register-form-inner
+    .card.mb-3
+      = form_with model: @user, class: 'card-body', local: true do |f|
+        = render 'shared/error_messages', object: @user
+        .form-group
+          = f.label :name, 'ユーザー名', class: 'bmd-label-floating'
+          = f.text_field :name, class: 'form-control'
+        .form-group
+          = f.label :email, ' メールアドレス', class: 'bmd-label-floating'
+          = f.text_field :email, class: 'form-control'
+        .form-group
+          = f.label :password, 'パスワード　', class: 'bmd-label-floating'
+          = f.password_field :password, class: 'form-control'
+        .form-group
+          = f.label :password_confirmation, "パスワード(確認)", class: 'bmd-label-floating'
+          = f.password_field :password_confirmation, class: 'form-control'
+        = f.submit '登録', class: 'btn btn-raised btn-primary'
+    .card
+      .card-body
+        | アカウントをお持ちですか
+        = link_to  "ログインする", login_path

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,14 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      post: 投稿
+    attributes:
+      user:
+        name: ユーザー名
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード(確認)
+      post:
+        content: 本文
+        images: 画像

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  content    :text(65535)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  post_id    :bigint
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_comments_on_post_id  (post_id)
+#  index_comments_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (post_id => posts.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :comment do
     content { Faker::Lorem.word }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -63,4 +63,6 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   #FactoryBotを導入
   config.include FactoryBot::Syntax::Methods
+  config.include LoginSupport
+
 end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,8 @@
+module LoginSupport
+  def login(user)
+    visit '/login'
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
+    click_on 'login'
+  end
+end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -53,7 +53,9 @@ RSpec.describe "Posts", type: :system do
 
     it '自分の投稿に編集ボタンが表示されること' do
       visit root_path
-      expect(page).to have_css '#edit'
+      within "#post-#{my_post.id}" do
+        expect(page).to have_css '.edit-button'
+      end
     end
 
 
@@ -85,21 +87,21 @@ RSpec.describe "Posts", type: :system do
 
     it '自分の投稿に削除ボタンが表示されること' do
       visit root_path
-      expect(page).to have_css '#delete'
+      expect(page).to have_css '.delete-button'
     end
 
     it '他人の投稿には削除ボタンが表示されないこと' do
       user.follow(other_post1.user)
       visit root_path
       within "#post-#{other_post1.id}" do
-        expect(page).to_not have_css '#delete'
+        expect(page).to_not have_css 'delete-button'
       end
     end
 
     it '投稿を削除できること' do
       visit root_path
       within "#post-#{my_post.id}" do
-        page.accept_confirm { find('#delete').click }
+        page.accept_confirm { find('.delete-button').click }
       end
       expect(page).to have_content("投稿を削除しました")
       expect(page).not_to have_content(my_post.content)
@@ -127,9 +129,9 @@ RSpec.describe "Posts", type: :system do
       visit root_path
       expect{
         within "#like_area-#{other_post1.id}" do
-          click_on 'like-button'
+          find('.like-button').click
         end
-        expect(page).to have_css '#unlike-button'
+        expect(page).to have_css '.unlike-button'
       }.to change(user.like_posts, :count).by(1)
     end
 
@@ -138,9 +140,9 @@ RSpec.describe "Posts", type: :system do
       visit root_path
       expect{
         within "#like_area-#{other_post1.id}" do
-          click_on 'unlike-button'
+          find('.unlike-button').click
         end
-        expect(page).to have_css '#like-button'
+        expect(page).to have_css '.like-button'
       }.to change(user.like_posts, :count).by(-1)
     end
   end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :system do
+  let!(:user) { create(:user) }
+  let!(:other_user) { create(:user) }
+  let!(:my_post) { create(:post, user: user) }
+  let!(:other_post) { create(:post, user: other_user) }
+
+
+  it '投稿一覧が閲覧できる' do
+    login(user)
+    visit '/'
+    expect(current_path).to eq '/'
+  end
+
+  it '新規投稿できる' do
+    login(user)
+    visit '/posts/new'
+    attach_file '画像', "#{Rails.root}/spec/fixtures/dummy.jpeg"
+    fill_in 'post_content', with: "test"
+    click_on '登録する'
+    expect(page).to have_content('投稿しました')
+  end
+
+  context '自分の投稿に' do
+    it '編集ボタンが表示される' do
+      user.follow(other_user)
+      login(user)
+      visit '/'
+      within "#post-#{my_post.id}" do
+        expect(page).to have_css '#edit'
+      end
+    end
+
+    it '削除ボタンが表示される' do
+      user.follow(other_user)
+      login(user)
+      visit '/'
+      within "#post-#{my_post.id}" do
+        expect(page).to have_css '#delete'
+      end
+    end
+  end
+
+  context '他人の投稿に' do
+
+    it '編集ボタンが表示されない' do
+      user.follow(other_user)
+      login(user)
+      visit '/'
+      within "#post-#{other_post.id}" do
+        expect(page).to_not have_css '#edit'
+      end
+    end
+
+    it '削除ボタンが表示されない' do
+      user.follow(other_user)
+      login(user)
+      visit '/'
+      within "#post-#{other_post.id}" do
+        expect(page).to_not have_css '#delete'
+      end
+    end
+  end
+
+  it '投稿を更新できる' do
+    login(user)
+    visit "/"
+    within "#post-#{my_post.id}" do
+      click_on 'edit'
+    end
+    expect(current_path).to eq "/posts/#{my_post.id}/edit"
+    attach_file '画像', "#{Rails.root}/spec/fixtures/dummy.jpeg"
+    fill_in 'post_content', with: "update"
+    click_on '登録する'
+    expect(page).to have_content('更新しました')
+  end
+
+  it '投稿を削除できる' do
+    login(user)
+    visit "/"
+    within "#post-#{my_post.id}" do
+      click_on 'delete'
+    end
+    expect{
+      expect(page.accept_confirm).to eq "本当に削除しますか？"
+      expect(page).to have_content "投稿を削除しました"
+    }.to change{ Post.count }.by(-1)
+  end
+
+  it '投稿の詳細画面が閲覧できる' do
+    login(user)
+    visit '/'
+    click_on 'show'
+    expect(current_path).to eq "/posts/#{my_post.id}"
+  end
+
+  describe 'いいね関連' do
+    it '投稿に対していいねができる' do
+      user.follow(other_user)
+      login(user)
+      visit '/'
+      within "#like_area-#{other_post.id}" do
+        click_on 'like-button'
+      end
+      expect(page).to have_css '#unlike-button'
+    end
+
+    it '投稿に対していいねを外させる' do
+      user.follow(other_user)
+      user.like(other_post)
+      login(user)
+      visit '/'
+      within "#like_area-#{other_post.id}" do
+        click_on 'unlike-button'
+      end
+      expect(page).to have_css '#like-button'
+    end
+  end
+end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Posts", type: :system do
       user.follow(other_post1.user)
       visit root_path
       within "#post-#{other_post1.id}" do
-        expect(page).to_not have_css '#edit'
+        expect(page).to_not have_css '.edit-button'
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe "Posts", type: :system do
       user.follow(other_post1.user)
       visit root_path
       within "#post-#{other_post1.id}" do
-        expect(page).to_not have_css 'delete-button'
+        expect(page).to_not have_css '.delete-button'
       end
     end
 

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :system do
+  let(:user) { create(:user) }
+
+  describe 'ログイン' do
+    it 'ユーザーがログイン後投稿一覧画面にリダイレクトされること' do
+      visit '/login'
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: 'password'
+      click_on 'login' #ヘッダーのログインに反応してしまうためid指定に変更
+      expect(current_path).to eq root_path
+    end
+  end
+
+  describe 'ログアウト' do
+    it 'ユーザーがログアウト後ログイン画面にリダイレクトされること' do
+      login(user)
+      click_on 'ログアウト'
+      expect(current_path).to eq '/login'
+    end
+  end
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -4,12 +4,26 @@ RSpec.describe "Sessions", type: :system do
   let(:user) { create(:user) }
 
   describe 'ログイン' do
-    it 'ユーザーがログイン後投稿一覧画面にリダイレクトされること' do
-      visit '/login'
-      fill_in 'メールアドレス', with: user.email
-      fill_in 'パスワード', with: 'password'
-      click_on 'login' #ヘッダーのログインに反応してしまうためid指定に変更
-      expect(current_path).to eq root_path
+    context '認証情報が正しい場合' do
+      it 'ログインできること' do
+        visit '/login'
+        fill_in 'メールアドレス', with: user.email
+        fill_in 'パスワード', with: 'password'
+        click_on 'login' #ヘッダーのログインに反応してしまうためid指定に変更(within使った方がよいかもしれない)
+        expect(current_path).to eq root_path
+        expect(page).to have_content 'ログインしました'
+      end
+    end
+
+    context '認証情報が誤りがある場合' do
+      it 'ログインできないこと' do
+        visit '/login'
+        fill_in 'メールアドレス', with: user.email
+        fill_in 'パスワード', with: 'misspassword'
+        click_on 'login' #ヘッダーのログインに反応してしまうためid指定に変更
+        expect(current_path).to eq login_path
+        expect(page).to have_content 'ログインに失敗しました'
+      end
     end
   end
 
@@ -18,6 +32,7 @@ RSpec.describe "Sessions", type: :system do
       login(user)
       click_on 'ログアウト'
       expect(current_path).to eq '/login'
+      expect(page).to have_content 'ログアウトしました'
     end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe "Users", type: :system do
   let!(:user) { create(:user) }
   let!(:other_user) { create(:user) }
-  let!(:post) { create(:post, user: user) }
-  let!(:ohter_post) { create(:post, user: other_user) }
+
 
   describe 'ユーザー登録' do
     it 'ユーザー登録が成功すること' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  let!(:user) { create(:user) }
+  let!(:other_user) { create(:user) }
+  let!(:post) { create(:post, user: user) }
+  let!(:ohter_post) { create(:post, user: other_user) }
+
+  describe 'ユーザー登録' do
+    it 'ユーザー登録が成功すること' do
+      visit '/users/new'
+      fill_in 'user_name', with: 'tetete'
+      fill_in 'user_email', with: 'tetete@example.com'
+      fill_in 'user_password', with: 'password'
+      fill_in 'user_password_confirmation', with: 'password'
+      click_on '登録'
+      expect(page).to have_content('ユーザーの作成に成功しました')
+    end
+
+    it 'ユーザー登録が失敗すること' do
+      visit '/users/new'
+      fill_in 'user_name', with: 'tetete'
+      fill_in 'user_email', with: 'tetete@example.com'
+      fill_in 'user_password', with: 'password'
+      fill_in 'user_password_confirmation', with: 'passwordpassword'
+      click_on '登録'
+      expect(page).to have_content('ユーザーの作成に失敗しました')
+    end
+  end
+
+  describe 'フォロー' do
+    it 'フォローができること' do
+      login(user)
+      visit '/users'
+      find("#follow-area-#{other_user.id}").click_on("follow")
+      expect(page).to have_css "#unfollow"
+    end
+
+    it 'フォローを外せること' do
+      login(user)
+      user.follow(other_user)
+      visit '/users'
+      find("#follow-area-#{other_user.id}").click_on("unfollow")
+      expect(page).to have_css "#follow"
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,46 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
-  let!(:user) { create(:user) }
-  let!(:other_user) { create(:user) }
-
 
   describe 'ユーザー登録' do
-    it 'ユーザー登録が成功すること' do
-      visit '/users/new'
-      fill_in 'user_name', with: 'tetete'
-      fill_in 'user_email', with: 'tetete@example.com'
-      fill_in 'user_password', with: 'password'
-      fill_in 'user_password_confirmation', with: 'password'
-      click_on '登録'
-      expect(page).to have_content('ユーザーの作成に成功しました')
+    context 'ユーザー情報が正しい場合' do
+      it 'ユーザー登録が成功すること' do
+        visit '/users/new'
+        fill_in 'user_name', with: 'tetete'
+        fill_in 'user_email', with: 'tetete@example.com'
+        fill_in 'user_password', with: 'password'
+        fill_in 'user_password_confirmation', with: 'password'
+        click_on '登録'
+        expect(current_path).to eq root_path
+        expect(page).to have_content('ユーザーの作成に成功しました')
+      end
     end
 
-    it 'ユーザー登録が失敗すること' do
-      visit '/users/new'
-      fill_in 'user_name', with: 'tetete'
-      fill_in 'user_email', with: 'tetete@example.com'
-      fill_in 'user_password', with: 'password'
-      fill_in 'user_password_confirmation', with: 'passwordpassword'
-      click_on '登録'
-      expect(page).to have_content('ユーザーの作成に失敗しました')
+    context 'ユーザー情報が誤りがある場合' do
+      it 'ユーザー登録が失敗すること' do
+        visit '/users/new'
+        fill_in 'user_name', with: ''
+        fill_in 'user_email', with: ''
+        fill_in 'user_password', with: ''
+        fill_in 'user_password_confirmation', with: ''
+        click_on '登録'
+        expect(page).to have_content('ユーザー名を入力してください')
+        expect(page).to have_content('メールアドレスを入力してください')
+        expect(page).to have_content('パスワードは3文字以上で入力してください')
+        expect(page).to have_content('パスワード(確認)を入力してください')
+        expect(page).to have_content('ユーザーの作成に失敗しました')
+      end
     end
   end
 
   describe 'フォロー' do
-    it 'フォローができること' do
+    let!(:user) { create(:user) }
+    let!(:other_user) { create(:user) }
+
+    before do
       login(user)
-      visit '/users'
-      find("#follow-area-#{other_user.id}").click_on("follow")
-      expect(page).to have_css "#unfollow"
+    end
+
+    it 'フォローができること' do
+      visit root_path
+      expect{
+        within "#follow-area-#{other_user.id}" do
+          click_on 'follow'
+          expect(page).to have_css('#unfollow')
+        end
+      }.to change(user.follows, :count).by(1)
     end
 
     it 'フォローを外せること' do
-      login(user)
       user.follow(other_user)
-      visit '/users'
-      find("#follow-area-#{other_user.id}").click_on("unfollow")
-      expect(page).to have_css "#follow"
+      visit root_path
+      expect{
+        within "#follow-area-#{other_user.id}" do
+          click_on 'unfollow'
+          expect(page).to have_css('#follow')
+        end
+      }.to change(user.follows, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
## 概要
session、user、postのシステムスペックを実装。

## UIの変更
この課題とは関係ないですが、リダイレクト時のフラッシュメッセージを導入。

[![Image from Gyazo](https://i.gyazo.com/a35f6e15a533f406611ce20491a3bbdb.png)](https://gyazo.com/a35f6e15a533f406611ce20491a3bbdb)

##  実装の詳細
下記の内容のテストを実装しました。
- ログインの成功/失敗
- ログアウトできること
- ユーザー登録成功/失敗
- フォローできること
- フォローをはずせることのテスト
- 投稿一覧が閲覧できる
- 新規投稿できる
- 自分の投稿に編集・削除ボタンが表示される
- 他人の投稿には編集・削除ボタンが表示されない
- 投稿を更新できる
- 投稿を削除できる
- 投稿の詳細画面が閲覧できる
- 投稿に対していいねできる
- 投稿に対していいねを外せる


## 追加したGem
- [webdrivers ver4.1.2](https://www.rubydoc.info/gems/webdrivers/4.1.2)

## 備考
ヘッドレス対応できていません。circleCI導入時に変更しようと思います。
差分に関しては、vscodeのlint機能とrubocopが競合しているため大きいです。お許しください🙇‍♂️
次回からrubymine使おうと思うのでこの問題点に関しては直っていると信じたい、、